### PR TITLE
Fix error: 'gcc' failed when install docker images

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -14,6 +14,6 @@
 
 FROM jupyter/scipy-notebook:latest
 USER root
-RUN apt-get update -y && apt-get install -qy graphviz libmysqlclient-dev mongodb-clients mysql-client wget host
+RUN apt-get update -y && apt-get install -qy gcc graphviz libmysqlclient-dev mongodb-clients mysql-client wget host
 RUN pip install presto-python-client pyhive graphviz mysqlclient mongo
 COPY f8_demo.ipynb /home/jovyan/


### PR DESCRIPTION
When I execute command line "docker-compose up" then this error comes up: "error: command 'gcc' failed: No such file or directory"